### PR TITLE
Adding krb5 lib to fix reportportal plugin on startup

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -20,6 +20,7 @@ RUN set -ex && \
     # install/update packages
     apk update --no-cache && \
     apk add --no-cache --update \
+        krb5 \
         gcc musl-dev linux-headers \
         ca-certificates \
         bash \


### PR DESCRIPTION
**Description:**

Fixes the following issue seen when the plugin in loaded at the start of a gauge test run

```Error loading shared library libgssapi_krb5.so.2: No such file or directory (needed by ./ReportPortal.GaugePlugin)
Error relocating ./ReportPortal.GaugePlugin: gss_inquire_context: symbol not found
Error relocating ./ReportPortal.GaugePlugin: gss_oid_equal: symbol not found
Error relocating ./ReportPortal.GaugePlugin: gss_release_buffer: symbol not found
Error relocating ./ReportPortal.GaugePlugin: gss_display_status: symbol not found
Error relocating ./ReportPortal.GaugePlugin: gss_init_sec_context: symbol not found
Error relocating ./ReportPortal.GaugePlugin: gss_acquire_cred: symbol not found
Error relocating ./ReportPortal.GaugePlugin: gss_release_cred: symbol not found
Error relocating ./ReportPortal.GaugePlugin: gss_wrap: symbol not found
Error relocating ./ReportPortal.GaugePlugin: gss_acquire_cred_with_password: symbol not found
Error relocating ./ReportPortal.GaugePlugin: gss_import_name: symbol not found
Error relocating ./ReportPortal.GaugePlugin: gss_delete_sec_context: symbol not found
Error relocating ./ReportPortal.GaugePlugin: gss_unwrap: symbol not found
Error relocating ./ReportPortal.GaugePlugin: gss_release_oid_set: symbol not found
Error relocating ./ReportPortal.GaugePlugin: gss_accept_sec_context: symbol not found
Error relocating ./ReportPortal.GaugePlugin: gss_release_name: symbol not found
Error relocating ./ReportPortal.GaugePlugin: gss_indicate_mechs: symbol not found
Error relocating ./ReportPortal.GaugePlugin: gss_display_name: symbol not found
Error relocating ./ReportPortal.GaugePlugin: GSS_C_NT_HOSTBASED_SERVICE: symbol not found
Error relocating ./ReportPortal.GaugePlugin: GSS_C_NT_USER_NAME: symbol not found
Error relocating ./ReportPortal.GaugePlugin: gss_mech_krb5: symbol not found
Error occurred while waiting for plugin process to finish.
Error : exit status 127

Tested by building base image and jdk11 locally with and without the addition of the lib and the error no longer occurs with it added.